### PR TITLE
[Feat] Add Summary API

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.1.3'
+	id 'org.springframework.boot' version '3.2.0'
 	id 'io.spring.dependency-management' version '1.1.3'
 }
 
@@ -38,6 +38,10 @@ dependencies {
 	implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
 	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
 	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
+
+	// https://mvnrepository.com/artifact/org.json/json
+	implementation group: 'org.json', name: 'json', version: '20231013'
+
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/multinewssummarizer/backend/global/config/security/SecurityConfig.java
+++ b/backend/src/main/java/multinewssummarizer/backend/global/config/security/SecurityConfig.java
@@ -29,7 +29,7 @@ public class SecurityConfig {
                 .cors(AbstractHttpConfigurer::disable)
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(requests ->
-                        requests.requestMatchers("/user/sign-up", "/user/sign-in").permitAll()
+                        requests.requestMatchers("/summary/**","/user/sign-up", "/user/sign-in").permitAll()
                                 .anyRequest().authenticated()
                 )
                 .sessionManagement(sessionManagement ->

--- a/backend/src/main/java/multinewssummarizer/backend/news/domain/News.java
+++ b/backend/src/main/java/multinewssummarizer/backend/news/domain/News.java
@@ -1,14 +1,12 @@
 package multinewssummarizer.backend.news.domain;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 @Entity
 @Getter @Setter
@@ -35,4 +33,7 @@ public class News {
 
     @Column(nullable = false)
     private LocalDateTime postTime;
+
+    @OneToMany(mappedBy = "news", cascade = CascadeType.ALL)
+    private List<NewsKeyword> keywords;
 }

--- a/backend/src/main/java/multinewssummarizer/backend/news/domain/NewsKeyword.java
+++ b/backend/src/main/java/multinewssummarizer/backend/news/domain/NewsKeyword.java
@@ -15,8 +15,8 @@ public class NewsKeyword {
     @Id @GeneratedValue
     private Long id;
 
-    @ManyToOne(cascade = CascadeType.REMOVE)
-    @JoinColumn(name = "news_id", referencedColumnName = "id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "news_id")
     News news;
 
     @Column(nullable = false)

--- a/backend/src/main/java/multinewssummarizer/backend/news/repository/NewsRepository.java
+++ b/backend/src/main/java/multinewssummarizer/backend/news/repository/NewsRepository.java
@@ -1,9 +1,12 @@
 package multinewssummarizer.backend.news.repository;
 
 import multinewssummarizer.backend.news.domain.News;
+import multinewssummarizer.backend.summary.model.SummaryRepositoryVO;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 
@@ -12,4 +15,13 @@ public interface NewsRepository extends JpaRepository<News, Long> {
     // 하루 전에 생성된 기사는 가져오는 쿼리문
     @Query(value = "SELECT id FROM News WHERE post_time >= current_timestamp - interval '1 day'", nativeQuery = true)
     List<Long> findNewsByPublishedWithinLastDay();
+
+    @Query(value = "SELECT DISTINCT new multinewssummarizer.backend.summary.model.SummaryRepositoryVO(n.id, n.link, n.title) FROM News n LEFT JOIN n.keywords k " +
+            "WHERE (:categoryParam IS NULL OR n.topic IN :categoryParam) " +
+            "AND (:keywordParam IS NULL OR k.keyword IN :keywordParam) " +
+            "AND n.postTime >= :oneDayAgo")
+    List<SummaryRepositoryVO> findNewsByCategoriesAndKeywords(
+            @Param("categoryParam") List<String> categoriesParam,
+            @Param("keywordParam") List<String> keywordsParam,
+            @Param("oneDayAgo")LocalDateTime oneDayAgo);
 }

--- a/backend/src/main/java/multinewssummarizer/backend/summary/controller/SummaryController.java
+++ b/backend/src/main/java/multinewssummarizer/backend/summary/controller/SummaryController.java
@@ -1,0 +1,33 @@
+package multinewssummarizer.backend.summary.controller;
+
+import lombok.RequiredArgsConstructor;
+import multinewssummarizer.backend.summary.model.SummaryRequestDto;
+import multinewssummarizer.backend.summary.model.SummaryResponseDto;
+import multinewssummarizer.backend.summary.service.SummaryService;
+import multinewssummarizer.backend.user.service.UserService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/summary")
+@RequiredArgsConstructor
+public class SummaryController {
+
+    private final UserService userService;
+    private final SummaryService summaryService;
+
+    @PostMapping("/instant")
+    public ResponseEntity<SummaryResponseDto> instantSummary(@RequestBody SummaryRequestDto summaryRequestDto) {
+        SummaryResponseDto news = summaryService.instantSummary(summaryRequestDto);
+        return new ResponseEntity<>(news, HttpStatus.OK);
+    }
+
+    @PostMapping("/test")
+    public ResponseEntity<SummaryResponseDto> testSummary(@RequestBody List<Long> ids) {
+        SummaryResponseDto news = summaryService.testSummary(ids);
+        return new ResponseEntity<>(news, HttpStatus.OK);
+    }
+}

--- a/backend/src/main/java/multinewssummarizer/backend/summary/model/SummaryRepositoryVO.java
+++ b/backend/src/main/java/multinewssummarizer/backend/summary/model/SummaryRepositoryVO.java
@@ -1,0 +1,18 @@
+package multinewssummarizer.backend.summary.model;
+
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class SummaryRepositoryVO {
+    private Long id;
+    private String link;
+    private String title;
+
+    public SummaryRepositoryVO(Long id, String link, String title) {
+        this.id = id;
+        this.link = link;
+        this.title = title;
+    }
+}

--- a/backend/src/main/java/multinewssummarizer/backend/summary/model/SummaryRequestDto.java
+++ b/backend/src/main/java/multinewssummarizer/backend/summary/model/SummaryRequestDto.java
@@ -1,0 +1,15 @@
+package multinewssummarizer.backend.summary.model;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
+import java.util.ArrayList;
+
+@Getter @Setter
+@ToString
+public class SummaryRequestDto {
+    private Long userId;
+    private ArrayList<String> categories;
+    private ArrayList<String> keywords;
+}

--- a/backend/src/main/java/multinewssummarizer/backend/summary/model/SummaryResponseDto.java
+++ b/backend/src/main/java/multinewssummarizer/backend/summary/model/SummaryResponseDto.java
@@ -1,0 +1,16 @@
+package multinewssummarizer.backend.summary.model;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class SummaryResponseDto {
+    private List<Long> ids;
+    private List<String> links;
+    private List<String> titles;
+    private String summary;
+}

--- a/backend/src/main/java/multinewssummarizer/backend/summary/service/SummaryService.java
+++ b/backend/src/main/java/multinewssummarizer/backend/summary/service/SummaryService.java
@@ -1,0 +1,105 @@
+package multinewssummarizer.backend.summary.service;
+
+import lombok.RequiredArgsConstructor;
+import multinewssummarizer.backend.news.repository.NewsRepository;
+import multinewssummarizer.backend.summary.model.SummaryRequestDto;
+import multinewssummarizer.backend.summary.model.SummaryResponseDto;
+import multinewssummarizer.backend.summary.model.SummaryRepositoryVO;
+import multinewssummarizer.backend.user.repository.UserRepository;
+import org.json.JSONObject;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class SummaryService {
+
+    private final UserRepository userRepository;
+    private final NewsRepository newsRepository;
+
+    private static String url = "https://dd24-116-255-71-186.ngrok-free.app/summary/";
+
+    @Transactional
+    public SummaryResponseDto instantSummary(SummaryRequestDto summaryRequestDto) {
+        ArrayList<String> categories = summaryRequestDto.getCategories();
+        ArrayList<String> keywords = summaryRequestDto.getKeywords();
+        LocalDateTime oneDayAgo = LocalDateTime.now().minusDays(1);
+
+        List<SummaryRepositoryVO> findNews = newsRepository.findNewsByCategoriesAndKeywords(categories, keywords, oneDayAgo);
+        List<Long> findIds = new ArrayList<>();
+        List<String> links = new ArrayList<>();
+        List<String> titles = new ArrayList<>();
+        for (SummaryRepositoryVO summaryRepositoryVO : findNews) {
+            findIds.add(summaryRepositoryVO.getId());
+            links.add(summaryRepositoryVO.getLink());
+            titles.add(summaryRepositoryVO.getTitle());
+        }
+
+        // POST 요청
+        RestTemplate rt = new RestTemplate();
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        JSONObject bodies = new JSONObject();
+        bodies.put("numbers", findIds);
+        HttpEntity<String> entity = new HttpEntity<>(bodies.toString(), headers);
+        String responseBody = rt.postForObject(url, entity, String.class);
+
+        /**TODO:
+         * 현재 요약을 한다면, {summary=['더불어민주당이 29일 전날 제출한 이동관 방송통신위원장에 대한 탄핵소추안을 철회한 뒤 다시 제출한다.', ... 민주당은 내년도 예산안 처리를 위해 30일과 다음 달 1일 본회의 일정이 확정돼 있다며 탄핵안을 처리한다는 계획이다.']}
+         * 결과로 출력이 된다. 그러나, 이를 VO나 MultiValueMap과 같이 ObjectMapping을 시도한다면, 오류가 발생한다.
+         * 아마, 개별적으로 파싱하여 값을 얻는 작업이 필요할 것 같다.
+         */
+
+        /**
+         * TODO: 만약, 오류가 발생했을 시, postForObject()로 시도한다면 에러세시지가 뜨지 않지만, exchange()로 한다면, <200 OK OK,{summary=}>로 뜬다. exception처리가 필요할수도
+         */
+
+        SummaryResponseDto summaryResponseDto = SummaryResponseDto.builder()
+                .ids(findIds)
+                .links(links)
+                .titles(titles)
+                .summary(responseBody)
+                .build();
+
+        return summaryResponseDto;
+    }
+
+    @Transactional
+    public SummaryResponseDto testSummary(List<Long> ids) {
+        // POST 요청
+        RestTemplate rt2 = new RestTemplate();
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        JSONObject body = new JSONObject();
+        body.put("numbers", ids);
+
+        HttpEntity<String> entity = new HttpEntity<>(body.toString(), headers);
+
+        try {
+//            ResponseEntity<?> responseBody = rt2.exchange(url, HttpMethod.POST, entity, Object.class);
+            String responseBody = rt2.postForObject(url, entity, String.class);
+            System.out.println("responseBody = " + responseBody);
+
+            SummaryResponseDto summaryResponseDto = SummaryResponseDto.builder()
+                    .ids(ids)
+                    .links(null)
+                    .titles(null)
+                    .summary(responseBody.toString())
+                    .build();
+
+            return summaryResponseDto;
+
+        } catch (Exception e) {
+            throw e;
+        }
+    }
+
+}

--- a/backend/src/test/java/multinewssummarizer/backend/news/repository/NewsRepositoryTest.java
+++ b/backend/src/test/java/multinewssummarizer/backend/news/repository/NewsRepositoryTest.java
@@ -1,0 +1,33 @@
+package multinewssummarizer.backend.news.repository;
+
+import multinewssummarizer.backend.summary.model.SummaryRepositoryVO;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Transactional
+@SpringBootTest
+class NewsRepositoryTest {
+
+    @Autowired
+    NewsRepository newsRepository;
+
+    @Test
+    void categoriesAndKeywords() {
+        List<String> categories = new ArrayList<>();
+        List<String> keywords = new ArrayList<>();
+        LocalDateTime oneDayAgo = LocalDateTime.now().minusDays(1);
+
+        categories.add("정치");
+        categories.add("경제");
+        List<SummaryRepositoryVO> output = newsRepository.findNewsByCategoriesAndKeywords(categories, null, oneDayAgo);
+        System.out.println("output = " + output);
+    }
+}


### PR DESCRIPTION
## 기능 설명 
- Add Instant Summary API
- When categories and keywords are given, find News that included, and return Summary Result
- For API content in detail, please check Notion

<br>


## Key Changes
- modified:   backend/build.gradle
- modified:   backend/src/main/java/multinewssummarizer/backend/global/config/security/SecurityConfig.java
- modified:   backend/src/main/java/multinewssummarizer/backend/news/domain/News.java
- modified:   backend/src/main/java/multinewssummarizer/backend/news/domain/NewsKeyword.java
- modified:   backend/src/main/java/multinewssummarizer/backend/news/repository/NewsRepository.java
- new file:   backend/src/main/java/multinewssummarizer/backend/summary/controller/SummaryController.java
- new file:   backend/src/main/java/multinewssummarizer/backend/summary/model/SummaryRepositoryVO.java
- new file:   backend/src/main/java/multinewssummarizer/backend/summary/model/SummaryRequestDto.java
- new file:   backend/src/main/java/multinewssummarizer/backend/summary/model/SummaryResponseDto.java
- new file:   backend/src/main/java/multinewssummarizer/backend/summary/service/SummaryService.java
- new file:   backend/src/test/java/multinewssummarizer/backend/news/repository/NewsRepositoryTest.java

<br>


## Related Issue
- issue #55

<br>
