### PR TITLE
[Feat] Add register keywords and topics API

### DIFF
--- a/backend/src/main/java/multinewssummarizer/backend/global/config/security/SecurityConfig.java
+++ b/backend/src/main/java/multinewssummarizer/backend/global/config/security/SecurityConfig.java
@@ -29,7 +29,7 @@ public class SecurityConfig {
                 .cors(AbstractHttpConfigurer::disable)
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(requests ->
-                        requests.requestMatchers("/summary/**","/user/sign-up", "/user/sign-in").permitAll()
+                        requests.requestMatchers("/summary/**","/usersign/sign-up", "/usersign/sign-in", "/user/**").permitAll()
                                 .anyRequest().authenticated()
                 )
                 .sessionManagement(sessionManagement ->

--- a/backend/src/main/java/multinewssummarizer/backend/global/config/security/SecurityConfig.java
+++ b/backend/src/main/java/multinewssummarizer/backend/global/config/security/SecurityConfig.java
@@ -29,7 +29,7 @@ public class SecurityConfig {
                 .cors(AbstractHttpConfigurer::disable)
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(requests ->
-                        requests.requestMatchers("/summary/**","/usersign/sign-up", "/usersign/sign-in", "/user/**").permitAll()
+                        requests.requestMatchers("/**","/summary/**","/usersign/sign-up", "/usersign/sign-in", "/user/**").permitAll()
                                 .anyRequest().authenticated()
                 )
                 .sessionManagement(sessionManagement ->

--- a/backend/src/main/java/multinewssummarizer/backend/news/repository/NewsKeywordRepository.java
+++ b/backend/src/main/java/multinewssummarizer/backend/news/repository/NewsKeywordRepository.java
@@ -4,13 +4,12 @@ import multinewssummarizer.backend.news.domain.NewsKeyword;
 import multinewssummarizer.backend.news.model.NewsKeywordDTO;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface NewsKeywordRepository extends JpaRepository<NewsKeyword, Long> {
-    List<NewsKeyword> findAllByNewsId(Long newsId);
-
     // 하루 전 뉴스 데이터에 해당하는 id를 통해 뉴스 데이터를 불러오는 쿼리문
     @Query("SELECT new multinewssummarizer.backend.news.model.NewsKeywordDTO(nk.keyword) FROM NewsKeyword nk WHERE nk.news.id IN :ids")
-    List<NewsKeywordDTO> findNewsKeywordsByNewsIds(List<Long> ids);
+    List<NewsKeywordDTO> findNewsKeywordsByNewsIds(@Param("ids") List<Long> ids);
 }

--- a/backend/src/main/java/multinewssummarizer/backend/news/service/NewsKeywordService.java
+++ b/backend/src/main/java/multinewssummarizer/backend/news/service/NewsKeywordService.java
@@ -14,10 +14,6 @@ public class NewsKeywordService {
 
     private final NewsKeywordRepository newsKeywordRepository;
 
-    public List<NewsKeyword> findAllByNewsId(Long newsId) {
-        return newsKeywordRepository.findAllByNewsId(newsId);
-    }
-
     public List<NewsKeywordDTO> findNewsKeywordsByNewsIds(List<Long> ids) {
         return newsKeywordRepository.findNewsKeywordsByNewsIds(ids);
     }

--- a/backend/src/main/java/multinewssummarizer/backend/user/controller/UserController.java
+++ b/backend/src/main/java/multinewssummarizer/backend/user/controller/UserController.java
@@ -1,0 +1,28 @@
+package multinewssummarizer.backend.user.controller;
+
+import lombok.RequiredArgsConstructor;
+import multinewssummarizer.backend.user.model.UserTopicAndKeywordRequestDto;
+import multinewssummarizer.backend.user.model.UserTopicAndKeywordResponseDto;
+import multinewssummarizer.backend.user.service.UserService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/user")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @PostMapping("/register")
+    public ResponseEntity<String> registerTopicsAndKeywords(@RequestBody UserTopicAndKeywordRequestDto userTopicAndKeywordRequestDto) {
+        Long userId = userService.registerTopicsAndKeywords(userTopicAndKeywordRequestDto);
+        return ResponseEntity.ok("OK");
+    }
+
+    @GetMapping("/topicsandkeywords")
+    public ResponseEntity<UserTopicAndKeywordResponseDto> getTopicsAndKeywords(@RequestParam("id") Long userId) {
+        UserTopicAndKeywordResponseDto topicsAndKeywords = userService.getTopicsAndKeywords(userId);
+        return ResponseEntity.ok(topicsAndKeywords);
+    }
+}

--- a/backend/src/main/java/multinewssummarizer/backend/user/controller/UserSignController.java
+++ b/backend/src/main/java/multinewssummarizer/backend/user/controller/UserSignController.java
@@ -13,14 +13,15 @@ import org.springframework.web.bind.annotation.*;
 
 
 @RestController
-@RequestMapping("/user")
+@RequestMapping("/usersign")
 @RequiredArgsConstructor
 public class UserSignController {
 
     private final UserService userService;
 
     @PostMapping("/sign-up")
-    public ResponseEntity<Long> signUp(@Valid @ModelAttribute UserSignUpRequestDto user) throws Exception {
+    public ResponseEntity<Long> signUp(@Valid @ModelAttribute UserSignUpRequestDto user) {
+        System.out.println("user = " + user);
         Long userId = userService.signUp(user);
         return ResponseEntity.ok(userId);
     }

--- a/backend/src/main/java/multinewssummarizer/backend/user/domain/Users.java
+++ b/backend/src/main/java/multinewssummarizer/backend/user/domain/Users.java
@@ -7,7 +7,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import java.time.LocalDate;
 
 @Entity
-@Getter
+@Getter @Setter
 @Builder
 @ToString
 @AllArgsConstructor
@@ -29,6 +29,12 @@ public class Users {
 
     @Column(nullable = false)
     private LocalDate birth;
+
+    @Column
+    private String topics;
+
+    @Column
+    private String keywords;
 
     public void encodePassword(PasswordEncoder passwordEncoder) {
         this.password = passwordEncoder.encode(password);

--- a/backend/src/main/java/multinewssummarizer/backend/user/model/UserSignUpRequestDto.java
+++ b/backend/src/main/java/multinewssummarizer/backend/user/model/UserSignUpRequestDto.java
@@ -1,12 +1,8 @@
 package multinewssummarizer.backend.user.model;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Pattern;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
+import lombok.*;
 import multinewssummarizer.backend.user.domain.Users;
 import org.springframework.format.annotation.DateTimeFormat;
 
@@ -14,7 +10,8 @@ import java.time.LocalDate;
 
 @Data
 @Builder
-@AllArgsConstructor
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class UserSignUpRequestDto {
 
     @NotBlank(message = "아이디를 입력해 주세요")
@@ -40,6 +37,8 @@ public class UserSignUpRequestDto {
                 .name(name)
                 .password(password)
                 .birth(birth)
+                .keywords(null)
+                .topics(null)
                 .build();
     }
 }

--- a/backend/src/main/java/multinewssummarizer/backend/user/model/UserTopicAndKeywordRequestDto.java
+++ b/backend/src/main/java/multinewssummarizer/backend/user/model/UserTopicAndKeywordRequestDto.java
@@ -1,0 +1,13 @@
+package multinewssummarizer.backend.user.model;
+
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter @Setter
+public class UserTopicAndKeywordRequestDto {
+    private Long userId;
+    private List<String> topics;
+    private List<String> keywords;
+}

--- a/backend/src/main/java/multinewssummarizer/backend/user/model/UserTopicAndKeywordResponseDto.java
+++ b/backend/src/main/java/multinewssummarizer/backend/user/model/UserTopicAndKeywordResponseDto.java
@@ -1,0 +1,13 @@
+package multinewssummarizer.backend.user.model;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class UserTopicAndKeywordResponseDto {
+    private List<String> topics;
+    private List<String> keywords;
+}

--- a/backend/src/test/java/multinewssummarizer/backend/news/service/NewsKeywordServiceTest.java
+++ b/backend/src/test/java/multinewssummarizer/backend/news/service/NewsKeywordServiceTest.java
@@ -6,6 +6,7 @@ import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -14,21 +15,11 @@ import java.util.List;
 import static org.junit.jupiter.api.Assertions.*;
 
 @SpringBootTest
+@Transactional(readOnly = true)
 class NewsKeywordServiceTest {
 
     @Autowired
     NewsKeywordService newsKeywordService;
-
-    @Test
-    void findNewsKeywordsByOneId() {
-        Long id = 2L;
-        List<NewsKeyword> allByNewsId = newsKeywordService.findAllByNewsId(id);
-
-        System.out.println("allByNewsId = " + allByNewsId);
-
-        Assertions.assertThat(allByNewsId).isNotEmpty();
-        Assertions.assertThat(allByNewsId.size()).isEqualTo(5);
-    }
 
     @Test
     void findNewsKeywordsByMultipleIds() {

--- a/backend/src/test/java/multinewssummarizer/backend/user/service/UserServiceTest.java
+++ b/backend/src/test/java/multinewssummarizer/backend/user/service/UserServiceTest.java
@@ -1,5 +1,6 @@
 package multinewssummarizer.backend.user.service;
 
+import multinewssummarizer.backend.global.exceptionhandler.CustomExceptions;
 import multinewssummarizer.backend.user.domain.Users;
 import multinewssummarizer.backend.user.model.UserSignInRequestDto;
 import multinewssummarizer.backend.user.model.UserSignUpRequestDto;
@@ -41,11 +42,28 @@ class UserServiceTest {
     @Transactional
     void wrongRegister() throws Exception{
         //given
-        UserSignUpRequestDto temp = new UserSignUpRequestDto("temp", "임시", "temp12", "temp12", LocalDate.parse("2023-11-29", formatter));
+        UserSignUpRequestDto temp = new UserSignUpRequestDto();
+        temp.setAccountId("temp");
+        temp.setName("임시");
+        temp.setPassword("temp12");
+        temp.setCheckedPassword("temp12");
+        temp.setBirth(LocalDate.parse("2023-11-29", formatter));
+
         userService.signUp(temp);
 
-        UserSignUpRequestDto duplicatedUser = new UserSignUpRequestDto("temp", "임시2", "temp123", "temp123", LocalDate.parse("2023-11-29", formatter));
-        UserSignUpRequestDto incorrectPasswordUser = new UserSignUpRequestDto("temp2", "임시2", "temp12", "temp123", LocalDate.parse("2023-11-29", formatter));
+        UserSignUpRequestDto duplicatedUser = new UserSignUpRequestDto();
+        duplicatedUser.setAccountId("temp");
+        duplicatedUser.setName("임시2");
+        duplicatedUser.setPassword("temp123");
+        duplicatedUser.setCheckedPassword("temp123");
+        duplicatedUser.setBirth(LocalDate.parse("2023-11-29", formatter));
+
+        UserSignUpRequestDto incorrectPasswordUser = new UserSignUpRequestDto();
+        incorrectPasswordUser.setAccountId("temp2");
+        incorrectPasswordUser.setName("임시2");
+        incorrectPasswordUser.setPassword("temp12");
+        incorrectPasswordUser.setCheckedPassword("temp123");
+        incorrectPasswordUser.setBirth(LocalDate.parse("2023-11-29", formatter));
 
         Assertions.assertThrows(Exception.class, () ->
                 userService.signUp(duplicatedUser));
@@ -58,7 +76,12 @@ class UserServiceTest {
     @Transactional
     void correctRegister() throws Exception{
         //given
-        UserSignUpRequestDto user = new UserSignUpRequestDto("temp", "임시", "temp12", "temp12", LocalDate.parse("2023-11-29", formatter));
+        UserSignUpRequestDto user = new UserSignUpRequestDto();
+        user.setAccountId("temp");
+        user.setName("임시");
+        user.setPassword("temp12");
+        user.setCheckedPassword("temp12");
+        user.setBirth(LocalDate.parse("2023-11-29", formatter));
         Long userId = userService.signUp(user);
 
         Optional<Users> out = userRepository.findById(userId);
@@ -73,15 +96,20 @@ class UserServiceTest {
     @Transactional
     void wrongSignIn() throws Exception{
         //given
-        UserSignUpRequestDto user = new UserSignUpRequestDto("temp", "임시", "temp12", "temp12", LocalDate.parse("2023-11-29", formatter));
+        UserSignUpRequestDto user = new UserSignUpRequestDto();
+        user.setAccountId("temp");
+        user.setName("임시");
+        user.setPassword("temp12");
+        user.setCheckedPassword("temp12");
+        user.setBirth(LocalDate.parse("2023-11-29", formatter));
         userService.signUp(user);
 
         UserSignInRequestDto request1 = new UserSignInRequestDto("wrong", "temp12");
         UserSignInRequestDto request2 = new UserSignInRequestDto("temp", "wrong");
-        Assertions.assertThrows(IllegalArgumentException.class, () ->
+        Assertions.assertThrows(CustomExceptions.IllegalArgumentLoginException.class, () ->
                 userService.signIn(request1));
 
-        Assertions.assertThrows(IllegalArgumentException.class, () ->
+        Assertions.assertThrows(CustomExceptions.IllegalArgumentLoginException.class, () ->
                 userService.signIn(request2));
     }
 
@@ -89,7 +117,12 @@ class UserServiceTest {
     @Transactional
     void correctSignIn() throws Exception{
         //given
-        UserSignUpRequestDto user = new UserSignUpRequestDto("temp", "임시", "temp12", "temp12", LocalDate.parse("2023-11-29", formatter));
+        UserSignUpRequestDto user = new UserSignUpRequestDto();
+        user.setAccountId("temp");
+        user.setName("임시");
+        user.setPassword("temp12");
+        user.setCheckedPassword("temp12");
+        user.setBirth(LocalDate.parse("2023-11-29", formatter));
         userService.signUp(user);
 
         UserSignInRequestDto request = new UserSignInRequestDto("temp", "temp12");


### PR DESCRIPTION
## 기능 설명 
- Add apis that add/modify user's topics and keywords
- /user/register : register topics and keywords
- /user/topicsandkeywords : get topics and keywords

<br>


## Key Changes
- modified:   backend/src/main/java/multinewssummarizer/backend/global/config/security/SecurityConfig.java
- modified:   backend/src/main/java/multinewssummarizer/backend/news/repository/NewsKeywordRepository.java
- modified:   backend/src/main/java/multinewssummarizer/backend/news/service/NewsKeywordService.java
- new file:   backend/src/main/java/multinewssummarizer/backend/user/controller/UserController.java
- modified:   backend/src/main/java/multinewssummarizer/backend/user/controller/UserSignController.java
- modified:   backend/src/main/java/multinewssummarizer/backend/user/domain/Users.java
- modified:   backend/src/main/java/multinewssummarizer/backend/user/model/UserSignUpRequestDto.java
- new file:   backend/src/main/java/multinewssummarizer/backend/user/model/UserTopicAndKeywordRequestDto.java
- new file:   backend/src/main/java/multinewssummarizer/backend/user/model/UserTopicAndKeywordResponseDto.java
- modified:   backend/src/main/java/multinewssummarizer/backend/user/service/UserService.java
- modified:   backend/src/test/java/multinewssummarizer/backend/news/service/NewsKeywordServiceTest.java
- modified:   backend/src/test/java/multinewssummarizer/backend/user/service/UserServiceTest.java
- modified:   backend/src/main/java/multinewssummarizer/backend/global/config/security/SecurityConfig.java


<br>


## Related Issue
- issue #59

<br>
