### PR TITLE
[Bug] Fix JPARespitory Query

### DIFF
--- a/backend/src/main/java/multinewssummarizer/backend/summary/service/SummaryService.java
+++ b/backend/src/main/java/multinewssummarizer/backend/summary/service/SummaryService.java
@@ -34,6 +34,13 @@ public class SummaryService {
         ArrayList<String> keywords = summaryRequestDto.getKeywords();
         LocalDateTime oneDayAgo = LocalDateTime.now().minusDays(1);
 
+        if (categories.isEmpty()) {
+            categories = null;
+        }
+        if (keywords.isEmpty()) {
+            keywords = null;
+        }
+
         List<SummaryRepositoryVO> findNews = newsRepository.findNewsByCategoriesAndKeywords(categories, keywords, oneDayAgo);
         System.out.println("findNews = " + findNews);
         List<Long> findIds = new ArrayList<>();


### PR DESCRIPTION
## 기능 설명 
- Fix bug that return empty results when categories or keywords params are empty

<br>


## Key Changes
- modified:   backend/src/main/java/multinewssummarizer/backend/summary/service/SummaryService.java

<br>


## Related Issue
- issue #68

<br>
