### PR TITLE
[Feat] Modify Summary API that save summary

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -39,8 +39,8 @@ dependencies {
 	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
 	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
 
-	// https://mvnrepository.com/artifact/org.json/json
-	implementation group: 'org.json', name: 'json', version: '20231013'
+	//JSON
+	implementation 'com.googlecode.json-simple:json-simple:1.1.1'
 
 }
 

--- a/backend/src/main/java/multinewssummarizer/backend/global/exceptionhandler/CustomExceptions.java
+++ b/backend/src/main/java/multinewssummarizer/backend/global/exceptionhandler/CustomExceptions.java
@@ -19,4 +19,8 @@ public class CustomExceptions{
             super(message);
         }
     }
+
+    public static class NoNewsDataException extends RuntimeException {
+        public NoNewsDataException(String message) {super(message);}
+    }
 }

--- a/backend/src/main/java/multinewssummarizer/backend/summary/controller/SummaryController.java
+++ b/backend/src/main/java/multinewssummarizer/backend/summary/controller/SummaryController.java
@@ -1,10 +1,12 @@
 package multinewssummarizer.backend.summary.controller;
 
 import lombok.RequiredArgsConstructor;
+import multinewssummarizer.backend.global.exceptionhandler.CustomExceptions;
 import multinewssummarizer.backend.summary.model.SummaryRequestDto;
 import multinewssummarizer.backend.summary.model.SummaryResponseDto;
 import multinewssummarizer.backend.summary.service.SummaryService;
 import multinewssummarizer.backend.user.service.UserService;
+import org.json.simple.parser.ParseException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -20,14 +22,19 @@ public class SummaryController {
     private final SummaryService summaryService;
 
     @PostMapping("/instant")
-    public ResponseEntity<SummaryResponseDto> instantSummary(@RequestBody SummaryRequestDto summaryRequestDto) {
+    public ResponseEntity<SummaryResponseDto> instantSummary(@RequestBody SummaryRequestDto summaryRequestDto) throws ParseException{
         SummaryResponseDto news = summaryService.instantSummary(summaryRequestDto);
         return new ResponseEntity<>(news, HttpStatus.OK);
     }
 
-    @PostMapping("/test")
-    public ResponseEntity<SummaryResponseDto> testSummary(@RequestBody List<Long> ids) {
-        SummaryResponseDto news = summaryService.testSummary(ids);
-        return new ResponseEntity<>(news, HttpStatus.OK);
+//    @PostMapping("/test")
+//    public ResponseEntity<SummaryResponseDto> testSummary(@RequestBody List<Long> ids) throws ParseException {
+//        SummaryResponseDto news = summaryService.testSummary(ids);
+//        return new ResponseEntity<>(news, HttpStatus.OK);
+//    }
+
+    @ExceptionHandler(CustomExceptions.NoNewsDataException.class)
+    public ResponseEntity<String> handleNoNewsException(CustomExceptions.NoNewsDataException ex) {
+        return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
     }
 }

--- a/backend/src/main/java/multinewssummarizer/backend/summary/domain/Summarize.java
+++ b/backend/src/main/java/multinewssummarizer/backend/summary/domain/Summarize.java
@@ -1,0 +1,35 @@
+package multinewssummarizer.backend.summary.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import multinewssummarizer.backend.user.domain.Users;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Summarize {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    Users users;
+
+    @Column(nullable = false)
+    private String summarize;
+
+    @Column
+    private String categories;
+
+    @Column
+    private String keywords;
+
+    @Builder
+    public Summarize (Users users, String summarize, String categories, String keywords) {
+        this.users = users;
+        this.summarize = summarize;
+        this.categories = categories;
+        this.keywords = keywords;
+    }
+}

--- a/backend/src/main/java/multinewssummarizer/backend/summary/repository/SummarizeRepository.java
+++ b/backend/src/main/java/multinewssummarizer/backend/summary/repository/SummarizeRepository.java
@@ -1,0 +1,7 @@
+package multinewssummarizer.backend.summary.repository;
+
+import multinewssummarizer.backend.summary.domain.Summarize;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface SummarizeRepository extends JpaRepository<Summarize, Long> {
+}

--- a/backend/src/main/java/multinewssummarizer/backend/user/domain/Users.java
+++ b/backend/src/main/java/multinewssummarizer/backend/user/domain/Users.java
@@ -2,9 +2,11 @@ package multinewssummarizer.backend.user.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
+import multinewssummarizer.backend.summary.domain.Summarize;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Entity
 @Getter @Setter
@@ -35,6 +37,9 @@ public class Users {
 
     @Column
     private String keywords;
+
+    @OneToMany(mappedBy = "summarize", cascade = CascadeType.ALL)
+    private List<Summarize> summarizes;
 
     public void encodePassword(PasswordEncoder passwordEncoder) {
         this.password = passwordEncoder.encode(password);


### PR DESCRIPTION
## 기능 설명 
- 요약이 완료되었을 때, 요약 내용과 함께 사용자가 선택한 주제/키워드를 Summarize 테이블에 저장하는 로직 구현
- 요약 api에서, 사용자가 선택한 주제/키워드에 해당하는 뉴스 데이터가 없을 경우, Bad Request를 전송하도록 설정.

<br>


## Key Changes
- backend/build.gradle
- backend/src/main/java/multinewssummarizer/backend/global/exceptionhandler/CustomExceptions.java
- backend/src/main/java/multinewssummarizer/backend/summary/controller/SummaryController.java
- backend/src/main/java/multinewssummarizer/backend/summary/domain/Summarize.java
- backend/src/main/java/multinewssummarizer/backend/summary/repository/SummarizeRepository.java
- backend/src/main/java/multinewssummarizer/backend/summary/service/SummaryService.java
- backend/src/main/java/multinewssummarizer/backend/user/domain/Users.java

<br>


## Related Issue
- issue #55 

<br>
