### PR TITLE
[Bug] Modify SQL Query when keywords and topics are both given

### DIFF
--- a/backend/src/main/java/multinewssummarizer/backend/news/repository/NewsRepository.java
+++ b/backend/src/main/java/multinewssummarizer/backend/news/repository/NewsRepository.java
@@ -17,8 +17,8 @@ public interface NewsRepository extends JpaRepository<News, Long> {
     List<Long> findNewsByPublishedWithinLastDay();
 
     @Query(value = "SELECT DISTINCT new multinewssummarizer.backend.summary.model.SummaryRepositoryVO(n.id, n.link, n.title) FROM News n LEFT JOIN n.keywords k " +
-            "WHERE (:categoryParam IS NULL OR n.topic IN :categoryParam) " +
-            "AND (:keywordParam IS NULL OR k.keyword IN :keywordParam) " +
+            "WHERE ((:categoryParam IS NULL OR n.topic IN :categoryParam) " +
+            "OR (:keywordParam IS NULL OR k.keyword IN :keywordParam)) " +
             "AND n.postTime >= :oneDayAgo")
     List<SummaryRepositoryVO> findNewsByCategoriesAndKeywords(
             @Param("categoryParam") List<String> categoriesParam,

--- a/backend/src/test/java/multinewssummarizer/backend/news/repository/NewsRepositoryTest.java
+++ b/backend/src/test/java/multinewssummarizer/backend/news/repository/NewsRepositoryTest.java
@@ -26,8 +26,8 @@ class NewsRepositoryTest {
         LocalDateTime oneDayAgo = LocalDateTime.now().minusDays(1);
 
         categories.add("정치");
-        categories.add("경제");
-        List<SummaryRepositoryVO> output = newsRepository.findNewsByCategoriesAndKeywords(categories, null, oneDayAgo);
+        keywords.add("경찰");
+        List<SummaryRepositoryVO> output = newsRepository.findNewsByCategoriesAndKeywords(categories, keywords, oneDayAgo);
         System.out.println("output = " + output);
     }
 }

--- a/backend/src/test/java/multinewssummarizer/backend/user/service/UserServiceTest.java
+++ b/backend/src/test/java/multinewssummarizer/backend/user/service/UserServiceTest.java
@@ -3,6 +3,7 @@ package multinewssummarizer.backend.user.service;
 import multinewssummarizer.backend.global.exceptionhandler.CustomExceptions;
 import multinewssummarizer.backend.user.domain.Users;
 import multinewssummarizer.backend.user.model.UserSignInRequestDto;
+import multinewssummarizer.backend.user.model.UserSignInResponseDto;
 import multinewssummarizer.backend.user.model.UserSignUpRequestDto;
 import multinewssummarizer.backend.user.repository.UserRepository;
 import org.junit.jupiter.api.Assertions;
@@ -126,10 +127,10 @@ class UserServiceTest {
         userService.signUp(user);
 
         UserSignInRequestDto request = new UserSignInRequestDto("temp", "temp12");
-        Long userId = userService.signIn(request);
-        assertThat(userId).isNotNull();
+        UserSignInResponseDto userSignInResponseDto = userService.signIn(request);
+        assertThat(userSignInResponseDto).isNotNull();
 
-        Optional<Users> out = userRepository.findById(userId);
+        Optional<Users> out = userRepository.findById(userSignInResponseDto.getUserId());
         Users findUser = out.get();
 
         assertThat(findUser.getAccountId()).isEqualTo(request.getAccountId());


### PR DESCRIPTION
## 기능 설명 
- 요약 API 버그 수정
- 기존에는 keywords와 categories 둘 다 주어졌을 경우, 두 조건을 모두 포함하는 뉴스 데이터들을 불러왔으나, 각각의 조건들에 해당하는 뉴스 데이터들을 불러오도록 변경

<br>


## Key Changes
- NewsRepository의 Query문 수정

<br>


## Related Issue
- issue #68

<br>
