### PR TITLE
[Bug] 요약 요청 시 발생한 문제 해결

### DIFF
--- a/backend/src/main/java/multinewssummarizer/backend/news/repository/NewsRepository.java
+++ b/backend/src/main/java/multinewssummarizer/backend/news/repository/NewsRepository.java
@@ -16,9 +16,12 @@ public interface NewsRepository extends JpaRepository<News, Long> {
     @Query(value = "SELECT id FROM News WHERE post_time >= current_timestamp - interval '1 day'", nativeQuery = true)
     List<Long> findNewsByPublishedWithinLastDay();
 
-    @Query(value = "SELECT DISTINCT new multinewssummarizer.backend.summary.model.SummaryRepositoryVO(n.id, n.link, n.title) FROM News n LEFT JOIN n.keywords k " +
-            "WHERE ((:categoryParam IS NULL OR n.topic IN :categoryParam) " +
-            "OR (:keywordParam IS NULL OR k.keyword IN :keywordParam)) " +
+    @Query(value = "SELECT DISTINCT new multinewssummarizer.backend.summary.model.SummaryRepositoryVO(n.id, n.link, n.title) FROM News n " +
+            "WHERE (:categoryParam IS NOT NULL AND n.topic IN :categoryParam) " +
+            "AND n.postTime >= :oneDayAgo " +
+            "UNION " +
+            "SELECT DISTINCT new multinewssummarizer.backend.summary.model.SummaryRepositoryVO(n.id, n.link, n.title) FROM News n LEFT JOIN n.keywords k " +
+            "WHERE (:keywordParam IS NOT NULL AND k.keyword IN :keywordParam) " +
             "AND n.postTime >= :oneDayAgo")
     List<SummaryRepositoryVO> findNewsByCategoriesAndKeywords(
             @Param("categoryParam") List<String> categoriesParam,

--- a/backend/src/test/java/multinewssummarizer/backend/news/repository/NewsRepositoryTest.java
+++ b/backend/src/test/java/multinewssummarizer/backend/news/repository/NewsRepositoryTest.java
@@ -26,7 +26,7 @@ class NewsRepositoryTest {
         LocalDateTime oneDayAgo = LocalDateTime.now().minusDays(1);
 
         categories.add("정치");
-        keywords.add("경찰");
+        keywords.add("밥");
         List<SummaryRepositoryVO> output = newsRepository.findNewsByCategoriesAndKeywords(categories, keywords, oneDayAgo);
         System.out.println("output = " + output);
     }


### PR DESCRIPTION
## 기능 설명 
- 요약을 요청할 때, 키워드나 카테고리 모두가 Null값이라면, 모든 뉴스 데이터가 불러와지던 문제 해결

<br>


## Key Changes
- NewsRepository의 @Query 내용 변경

<br>


## Related Issue
- issue #68

<br>
