### PR TITLE
[Feat] 유저 회원가입 시 발생하는 예외 처리

### DIFF
--- a/backend/src/main/java/multinewssummarizer/backend/user/controller/UserSignController.java
+++ b/backend/src/main/java/multinewssummarizer/backend/user/controller/UserSignController.java
@@ -9,6 +9,8 @@ import multinewssummarizer.backend.user.model.UserSignUpRequestDto;
 import multinewssummarizer.backend.user.service.UserService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.*;
 
@@ -39,7 +41,8 @@ public class UserSignController {
 
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<String> handleValidationException(MethodArgumentNotValidException ex) {
-        return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
+        String defaultMessage = ex.getBindingResult().getFieldError().getDefaultMessage();
+        return new ResponseEntity<>(defaultMessage, HttpStatus.BAD_REQUEST);
     }
 
     @PostMapping("/sign-in")


### PR DESCRIPTION
## 기능 설명 
- 회원가입 시, 비밀번호의 조건이 맞지 않을 경우 에러 메시지만 출력되는 것이 아닌 Spring의 @Validation오류 메시지 전체가 출력되는 문제 발생
- 이를 내부의 defaultMessage만 가지고 옴으로써 해결

<br>


## Key Changes
- UserSignController의 @ExceptionHandler의 내부 로직에서 FieldError의 default 메시지 만을 가져오도록 변경

<br>


## Related Issue
- issue #47

<br>