### PR TITLE
[Feat] DB schema 수정으로 인한 백엔드 코드 수정

### DIFF
--- a/backend/src/main/java/multinewssummarizer/backend/news/repository/NewsRepository.java
+++ b/backend/src/main/java/multinewssummarizer/backend/news/repository/NewsRepository.java
@@ -16,11 +16,11 @@ public interface NewsRepository extends JpaRepository<News, Long> {
     @Query(value = "SELECT id FROM News WHERE post_time >= current_timestamp - interval '1 day'", nativeQuery = true)
     List<Long> findNewsByPublishedWithinLastDay();
 
-    @Query(value = "SELECT DISTINCT new multinewssummarizer.backend.summary.model.SummaryRepositoryVO(n.id, n.link, n.title) FROM News n " +
+    @Query(value = "SELECT DISTINCT new multinewssummarizer.backend.summary.model.SummaryRepositoryVO(n.id, n.link, n.title, n.context) FROM News n " +
             "WHERE (:categoryParam IS NOT NULL AND n.topic IN :categoryParam) " +
             "AND n.postTime >= :oneDayAgo " +
             "UNION " +
-            "SELECT DISTINCT new multinewssummarizer.backend.summary.model.SummaryRepositoryVO(n.id, n.link, n.title) FROM News n LEFT JOIN n.keywords k " +
+            "SELECT DISTINCT new multinewssummarizer.backend.summary.model.SummaryRepositoryVO(n.id, n.link, n.title, n.context) FROM News n LEFT JOIN n.keywords k " +
             "WHERE (:keywordParam IS NOT NULL AND k.keyword IN :keywordParam) " +
             "AND n.postTime >= :oneDayAgo")
     List<SummaryRepositoryVO> findNewsByCategoriesAndKeywords(

--- a/backend/src/main/java/multinewssummarizer/backend/summary/domain/BatchResult.java
+++ b/backend/src/main/java/multinewssummarizer/backend/summary/domain/BatchResult.java
@@ -1,0 +1,38 @@
+package multinewssummarizer.backend.summary.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import multinewssummarizer.backend.user.domain.Users;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class BatchResult {
+
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    Users users;
+
+    @Column(nullable = false)
+    private String summarize;
+
+    @Column
+    private String categories;
+
+    @Column
+    private String keywords;
+
+    @Column(nullable = false)
+    private String newsIds;
+
+    @Column(nullable = false)
+    private LocalDateTime createdTime;
+
+}

--- a/backend/src/main/java/multinewssummarizer/backend/summary/domain/SummarizeLog.java
+++ b/backend/src/main/java/multinewssummarizer/backend/summary/domain/SummarizeLog.java
@@ -4,10 +4,14 @@ import jakarta.persistence.*;
 import lombok.*;
 import multinewssummarizer.backend.user.domain.Users;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Getter
-@NoArgsConstructor
-public class Summarize {
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class SummarizeLog {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -25,11 +29,13 @@ public class Summarize {
     @Column
     private String keywords;
 
-    @Builder
-    public Summarize (Users users, String summarize, String categories, String keywords) {
-        this.users = users;
-        this.summarize = summarize;
-        this.categories = categories;
-        this.keywords = keywords;
-    }
+    @Column(nullable = false)
+    private String newsIds;
+
+    @Column(nullable = false)
+    private LocalDateTime createdTime;
+
+    @Column(name = "batchnews_id")
+    private Long batchNewsId;
+
 }

--- a/backend/src/main/java/multinewssummarizer/backend/summary/model/SummaryRepositoryVO.java
+++ b/backend/src/main/java/multinewssummarizer/backend/summary/model/SummaryRepositoryVO.java
@@ -9,10 +9,12 @@ public class SummaryRepositoryVO {
     private Long id;
     private String link;
     private String title;
+    private String context;
 
-    public SummaryRepositoryVO(Long id, String link, String title) {
+    public SummaryRepositoryVO(Long id, String link, String title, String context) {
         this.id = id;
         this.link = link;
         this.title = title;
+        this.context = context;
     }
 }

--- a/backend/src/main/java/multinewssummarizer/backend/summary/model/SummaryResponseDto.java
+++ b/backend/src/main/java/multinewssummarizer/backend/summary/model/SummaryResponseDto.java
@@ -12,5 +12,6 @@ public class SummaryResponseDto {
     private List<Long> ids;
     private List<String> links;
     private List<String> titles;
+    private List<String> contexts;
     private String summary;
 }

--- a/backend/src/main/java/multinewssummarizer/backend/summary/repository/BatchResultRepository.java
+++ b/backend/src/main/java/multinewssummarizer/backend/summary/repository/BatchResultRepository.java
@@ -1,0 +1,7 @@
+package multinewssummarizer.backend.summary.repository;
+
+import multinewssummarizer.backend.summary.domain.BatchResult;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BatchResultRepository extends JpaRepository<BatchResult, Long> {
+}

--- a/backend/src/main/java/multinewssummarizer/backend/summary/repository/SummarizeRepository.java
+++ b/backend/src/main/java/multinewssummarizer/backend/summary/repository/SummarizeRepository.java
@@ -1,14 +1,13 @@
 package multinewssummarizer.backend.summary.repository;
 
-import multinewssummarizer.backend.summary.domain.Summarize;
+import multinewssummarizer.backend.summary.domain.SummarizeLog;
 import multinewssummarizer.backend.user.domain.Users;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
-public interface SummarizeRepository extends JpaRepository<Summarize, Long> {
+public interface SummarizeRepository extends JpaRepository<SummarizeLog, Long> {
 
-    List<Summarize> findByUsers(Users findUser);
+    List<SummarizeLog> findByUsers(Users findUser);
 
 }

--- a/backend/src/main/java/multinewssummarizer/backend/user/domain/Users.java
+++ b/backend/src/main/java/multinewssummarizer/backend/user/domain/Users.java
@@ -2,11 +2,9 @@ package multinewssummarizer.backend.user.domain;
 
 import jakarta.persistence.*;
 import lombok.*;
-import multinewssummarizer.backend.summary.domain.Summarize;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.time.LocalDate;
-import java.util.List;
 
 @Entity
 @Getter @Setter

--- a/backend/src/main/java/multinewssummarizer/backend/user/service/UserService.java
+++ b/backend/src/main/java/multinewssummarizer/backend/user/service/UserService.java
@@ -2,7 +2,6 @@ package multinewssummarizer.backend.user.service;
 
 import lombok.RequiredArgsConstructor;
 import multinewssummarizer.backend.global.exceptionhandler.CustomExceptions;
-import multinewssummarizer.backend.summary.domain.Summarize;
 import multinewssummarizer.backend.user.domain.Users;
 import multinewssummarizer.backend.user.model.*;
 import multinewssummarizer.backend.user.repository.UserRepository;
@@ -12,7 +11,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 
 @Service
 @Transactional(readOnly = true)


### PR DESCRIPTION
## 기능 설명 
- DB schema가 변경되면서, 그에 파생되는 코드 수정
- 뉴스 요약 API에서 변경 사항 적용 및 요약 시 리턴 요소 수정으로 인한 내부 로직 변경

<br>


## Key Changes
- 기존의 Summarize 테이블 삭제 및 BatchResult와 SummarizeLog의 추가
- 해당 테이블들이 추가됨으로써, 관련된 Repository추가
- 요약 시 응답으로 뉴스 본문이 필요함으로, 내부 로직을 수정함으로써 해당 값을 리턴

<br>


## Related Issue
- issue #94 

<br>
