### PR TITLE
[Bug] JPA 테이블 매핑 오류 해결

### DIFF
--- a/backend/src/main/java/multinewssummarizer/backend/summary/domain/SummarizeLog.java
+++ b/backend/src/main/java/multinewssummarizer/backend/summary/domain/SummarizeLog.java
@@ -7,6 +7,7 @@ import multinewssummarizer.backend.user.domain.Users;
 import java.time.LocalDateTime;
 
 @Entity
+@Table(name = "SummarizeLog")
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)


### PR DESCRIPTION
## 기능 설명 
- Java의 Cammel Case 명칭 문제로 인해, JPA를 통해 테이블을 불러올 때, snake case로 변환하여 테이블을 찾는 문제 발생
- domain에 테이블 이름을 명시적으로 기록함으로써 문제 해결

<br>


## Key Changes
- @Table(name = "SummarizeLog")로 명시적으로 테이블명 기재

<br>


## Related Issue
- issue #94

<br>