### PR TITLE
[Bug] Fix Table Matching Error

### DIFF
--- a/backend/src/main/java/multinewssummarizer/backend/summary/domain/Summarizelog.java
+++ b/backend/src/main/java/multinewssummarizer/backend/summary/domain/Summarizelog.java
@@ -7,12 +7,12 @@ import multinewssummarizer.backend.user.domain.Users;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "SummarizeLog")
+@Table
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class SummarizeLog {
+public class Summarizelog {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/backend/src/main/java/multinewssummarizer/backend/summary/repository/SummarizelogRepository.java
+++ b/backend/src/main/java/multinewssummarizer/backend/summary/repository/SummarizelogRepository.java
@@ -1,13 +1,13 @@
 package multinewssummarizer.backend.summary.repository;
 
-import multinewssummarizer.backend.summary.domain.SummarizeLog;
+import multinewssummarizer.backend.summary.domain.Summarizelog;
 import multinewssummarizer.backend.user.domain.Users;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
-public interface SummarizeRepository extends JpaRepository<SummarizeLog, Long> {
+public interface SummarizelogRepository extends JpaRepository<Summarizelog, Long> {
 
-    List<SummarizeLog> findByUsers(Users findUser);
+    List<Summarizelog> findByUsers(Users findUser);
 
 }

--- a/backend/src/main/java/multinewssummarizer/backend/summary/service/SummaryService.java
+++ b/backend/src/main/java/multinewssummarizer/backend/summary/service/SummaryService.java
@@ -4,12 +4,12 @@ import lombok.RequiredArgsConstructor;
 import multinewssummarizer.backend.global.exceptionhandler.CustomExceptions;
 import multinewssummarizer.backend.news.repository.NewsRepository;
 import multinewssummarizer.backend.summary.domain.BatchResult;
-import multinewssummarizer.backend.summary.domain.SummarizeLog;
+import multinewssummarizer.backend.summary.domain.Summarizelog;
 import multinewssummarizer.backend.summary.model.SummaryRequestDto;
 import multinewssummarizer.backend.summary.model.SummaryResponseDto;
 import multinewssummarizer.backend.summary.model.SummaryRepositoryVO;
 import multinewssummarizer.backend.summary.repository.BatchResultRepository;
-import multinewssummarizer.backend.summary.repository.SummarizeRepository;
+import multinewssummarizer.backend.summary.repository.SummarizelogRepository;
 import multinewssummarizer.backend.user.domain.Users;
 import multinewssummarizer.backend.summary.model.UserSummaryResponseDto;
 import multinewssummarizer.backend.user.repository.UserRepository;
@@ -31,7 +31,7 @@ import java.util.*;
 public class SummaryService {
 
     private final UserRepository userRepository;
-    private final SummarizeRepository summarizeRepository;
+    private final SummarizelogRepository summarizeLogRepository;
     private final NewsRepository newsRepository;
     private final BatchResultRepository batchResultRepository;
 
@@ -85,7 +85,7 @@ public class SummaryService {
         String strKeywords = convertToString(keywords);
 
         Users findUser = userRepository.findById(summaryRequestDto.getUserId()).get();
-        SummarizeLog summarizeLog = SummarizeLog.builder()
+        Summarizelog summarizeLog = Summarizelog.builder()
                 .users(findUser)
                 .summarize(summary)
                 .categories(strCategories)
@@ -94,7 +94,7 @@ public class SummaryService {
                 .createdTime(LocalDateTime.now())
                 .batchNewsId(null)
                 .build();
-        summarizeRepository.save(summarizeLog);
+        summarizeLogRepository.save(summarizeLog);
 
         /**
          * TODO: 만약, 오류가 발생했을 시, postForObject()로 시도한다면 에러세시지가 뜨지 않지만, exchange()로 한다면, <200 OK OK,{summary=}>로 뜬다. exception처리가 필요할수도
@@ -187,10 +187,10 @@ public class SummaryService {
     @Transactional
     public List<UserSummaryResponseDto> getUserSummaryLogs(Long id) {
         Users findUser = userRepository.findById(id).get();
-        List<SummarizeLog> findSummarizeLogs = summarizeRepository.findByUsers(findUser);
+        List<Summarizelog> findSummarizeLogs = summarizeLogRepository.findByUsers(findUser);
 
         List<UserSummaryResponseDto> response = new ArrayList<>();
-        for (SummarizeLog summarizeLog : findSummarizeLogs) {
+        for (Summarizelog summarizeLog : findSummarizeLogs) {
             response.add(UserSummaryResponseDto.builder()
                     .summary(summarizeLog.getSummarize())
                     .categories(summarizeLog.getCategories())

--- a/backend/src/main/java/multinewssummarizer/backend/user/domain/Users.java
+++ b/backend/src/main/java/multinewssummarizer/backend/user/domain/Users.java
@@ -10,8 +10,8 @@ import java.time.LocalDate;
 @Getter @Setter
 @Builder
 @ToString
-@AllArgsConstructor
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
 public class Users {
 
     @Id

--- a/backend/src/test/java/multinewssummarizer/backend/summary/repository/SummarizelogRepositoryTest.java
+++ b/backend/src/test/java/multinewssummarizer/backend/summary/repository/SummarizelogRepositoryTest.java
@@ -1,0 +1,55 @@
+package multinewssummarizer.backend.summary.repository;
+
+import multinewssummarizer.backend.summary.domain.Summarizelog;
+import multinewssummarizer.backend.user.domain.Users;
+import multinewssummarizer.backend.user.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@SpringBootTest
+@Transactional
+class SummarizelogRepositoryTest {
+
+    String pattern = "yyyy-MM-dd";
+    DateTimeFormatter formatter = DateTimeFormatter.ofPattern(pattern);
+
+    @Autowired
+    SummarizelogRepository summarizelogRepository;
+
+    @Autowired
+    UserRepository userRepository;
+
+    @BeforeEach
+    void beforeEach() {
+        summarizelogRepository.deleteAllInBatch();
+    }
+
+    @Test
+    void add() {
+        //given
+        Users user = new Users();
+        user.setAccountId("temp");
+        user.setName("임시");
+        user.setPassword("temp1234");
+        user.setBirth(LocalDate.parse("2023-12-06", formatter));
+        Users savedUser = userRepository.save(user);
+
+        Summarizelog summarizelog = Summarizelog.builder()
+                .users(savedUser)
+                .summarize("요약")
+                .keywords("키워드")
+                .categories("카테고리")
+                .newsIds("뉴스 id")
+                .createdTime(LocalDateTime.now())
+                .batchNewsId(null)
+                .build();
+        Summarizelog savedSummarizeLog = summarizelogRepository.save(summarizelog);
+    }
+}


### PR DESCRIPTION
## 기능 설명 
- JPA가 SummaryLog 테이블을 사용할 때, 자동으로 snake case로 변환하여 저장.
- 그러나, 실제 db에는 SummaryLog라는 테이블명으로 저장되어 있기 때문에, 테이블명이 매칭되지 않는 문제 발생
- SummaryLog를 Summarylog로 수정함으로써 해결

<br>


## Key Changes
- SummaryLog를 Summarylog로 수정

<br>


## Related Issue
- issue #94

<br>