### PR TITLE
[Feat] 로그인 API 응답 내용 변경

### DIFF
--- a/backend/src/main/java/multinewssummarizer/backend/user/model/UserSignInResponseDto.java
+++ b/backend/src/main/java/multinewssummarizer/backend/user/model/UserSignInResponseDto.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 @Builder
 public class UserSignInResponseDto {
     private Long userId;
+    private String name;
     private Boolean keywords;
     private Boolean categories;
 }

--- a/backend/src/main/java/multinewssummarizer/backend/user/service/UserService.java
+++ b/backend/src/main/java/multinewssummarizer/backend/user/service/UserService.java
@@ -74,6 +74,7 @@ public class UserService {
 
         UserSignInResponseDto userSignInResponseDto = UserSignInResponseDto.builder()
                 .userId(findUser.getId())
+                .name(findUser.getName())
                 .categories(categories)
                 .keywords(keywords)
                 .build();


### PR DESCRIPTION
## 기능 설명 
- 로그인에 성공하였을 시, 응답 내용에 사용자의 이름을 추가

<br>


## Key Changes
- 응답 내용에 해당하는 UserSignInResponseDto에, 사용자명 변수를 추가

<br>


## Related Issue
- issue #47

<br>