### PR TITLE
[Feat] 배치 요약 결과를 반환하는 API 개발

### DIFF
--- a/backend/src/main/java/multinewssummarizer/backend/global/exceptionhandler/CustomExceptions.java
+++ b/backend/src/main/java/multinewssummarizer/backend/global/exceptionhandler/CustomExceptions.java
@@ -23,4 +23,8 @@ public class CustomExceptions{
     public static class NoNewsDataException extends RuntimeException {
         public NoNewsDataException(String message) {super(message);}
     }
+
+    public static class NoBatchNewsDataException extends RuntimeException {
+        public NoBatchNewsDataException(String message) {super(message);}
+    }
 }

--- a/backend/src/main/java/multinewssummarizer/backend/summary/controller/SummaryController.java
+++ b/backend/src/main/java/multinewssummarizer/backend/summary/controller/SummaryController.java
@@ -2,6 +2,7 @@ package multinewssummarizer.backend.summary.controller;
 
 import lombok.RequiredArgsConstructor;
 import multinewssummarizer.backend.global.exceptionhandler.CustomExceptions;
+import multinewssummarizer.backend.summary.model.BatchSummaryResponseDto;
 import multinewssummarizer.backend.summary.model.SummaryRequestDto;
 import multinewssummarizer.backend.summary.model.SummaryResponseDto;
 import multinewssummarizer.backend.summary.service.SummaryService;
@@ -41,5 +42,16 @@ public class SummaryController {
     public ResponseEntity<Boolean> batchSummary() throws ParseException {
         boolean response = summaryService.batchSummary();
         return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/getlastbatchsummary")
+    public ResponseEntity<BatchSummaryResponseDto> getLastBatchSummary(@RequestParam("id") Long userId) {
+        BatchSummaryResponseDto lastBatchSummary = summaryService.getLastBatchSummary(userId);
+        return ResponseEntity.ok(lastBatchSummary);
+    }
+
+    @ExceptionHandler(CustomExceptions.NoBatchNewsDataException.class)
+    public ResponseEntity<String> handleNoBatchNewsDataException(CustomExceptions.NoBatchNewsDataException ex) {
+        return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
     }
 }

--- a/backend/src/main/java/multinewssummarizer/backend/summary/model/BatchSummaryNewsVO.java
+++ b/backend/src/main/java/multinewssummarizer/backend/summary/model/BatchSummaryNewsVO.java
@@ -1,0 +1,14 @@
+package multinewssummarizer.backend.summary.model;
+
+import lombok.*;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class BatchSummaryNewsVO {
+    private String title;
+    private String context;
+    private String companyName;
+    private String link;
+}

--- a/backend/src/main/java/multinewssummarizer/backend/summary/model/BatchSummaryResponseDto.java
+++ b/backend/src/main/java/multinewssummarizer/backend/summary/model/BatchSummaryResponseDto.java
@@ -1,0 +1,14 @@
+package multinewssummarizer.backend.summary.model;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor
+public class BatchSummaryResponseDto {
+    private String summary;
+    private List<BatchSummaryNewsVO> news;
+}

--- a/backend/src/main/java/multinewssummarizer/backend/summary/repository/BatchresultRepository.java
+++ b/backend/src/main/java/multinewssummarizer/backend/summary/repository/BatchresultRepository.java
@@ -1,7 +1,14 @@
 package multinewssummarizer.backend.summary.repository;
 
 import multinewssummarizer.backend.summary.domain.Batchresult;
+import multinewssummarizer.backend.user.domain.Users;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface BatchresultRepository extends JpaRepository<Batchresult, Long> {
+    @Query(value = "SELECT b FROM Batchresult b WHERE b.users = :user ORDER BY b.id DESC LIMIT 1")
+    Optional<Batchresult> findLastSummaryByUserId(@Param("user") Users user);
 }

--- a/backend/src/main/java/multinewssummarizer/backend/summary/repository/SummarizelogRepository.java
+++ b/backend/src/main/java/multinewssummarizer/backend/summary/repository/SummarizelogRepository.java
@@ -3,11 +3,16 @@ package multinewssummarizer.backend.summary.repository;
 import multinewssummarizer.backend.summary.domain.Summarizelog;
 import multinewssummarizer.backend.user.domain.Users;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface SummarizelogRepository extends JpaRepository<Summarizelog, Long> {
 
     List<Summarizelog> findByUsers(Users findUser);
 
+    @Query(value = "SELECT s FROM Summarizelog s WHERE s.batchNewsId = :batchNewsId")
+    Optional<Summarizelog> findByBatchnewsId(@Param("batchNewsId") Long batchNewsId);
 }

--- a/backend/src/test/java/multinewssummarizer/backend/summary/repository/SummarizelogRepositoryTest.java
+++ b/backend/src/test/java/multinewssummarizer/backend/summary/repository/SummarizelogRepositoryTest.java
@@ -3,6 +3,7 @@ package multinewssummarizer.backend.summary.repository;
 import multinewssummarizer.backend.summary.domain.Summarizelog;
 import multinewssummarizer.backend.user.domain.Users;
 import multinewssummarizer.backend.user.repository.UserRepository;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,6 +13,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Optional;
 
 @SpringBootTest
 @Transactional
@@ -22,13 +24,14 @@ class SummarizelogRepositoryTest {
 
     @Autowired
     SummarizelogRepository summarizelogRepository;
-
     @Autowired
     UserRepository userRepository;
 
     @BeforeEach
     void beforeEach() {
         summarizelogRepository.deleteAllInBatch();
+        userRepository.deleteAllInBatch();
+
     }
 
     @Test
@@ -51,5 +54,10 @@ class SummarizelogRepositoryTest {
                 .batchNewsId(null)
                 .build();
         Summarizelog savedSummarizeLog = summarizelogRepository.save(summarizelog);
+        Optional<Summarizelog> byBatchnewsId = summarizelogRepository.findByBatchnewsId(15L);
+
+        Assertions.assertThat(byBatchnewsId).isEmpty();
     }
+
+
 }


### PR DESCRIPTION
## 기능 설명 
- 배치 요약 결과 중 가장 최신 요약 결과를 반환하는 API 개발
- 만약 해당 결과가 듣기 기록에 존재하지 않는다면, 이를 SummarizeLog에 추가

<br>


## Key Changes
- 서비스 부분에서, 특정 유저에 대한 BatchResult 중 가장 최신의 요약 결과를 불러옴
- 해당 요약 결과가 SummarizeLog에 존재하지 않는다면, 해당 결과를 저장
- BatchSummaryResponseDto의 변수에 맞춰 데이터를 가공하고, 해당 데이터들을 반환

<br>


## Related Issue
- issue #100

<br>


## To Reviewers 
- 자세한 API Input, Ouput은 노션 참조

<br>