### PR TITLE
[Feat] 요약 기록 요청 시 반환 데이터 변경

### DIFF
--- a/backend/src/main/java/multinewssummarizer/backend/global/exceptionhandler/CustomExceptions.java
+++ b/backend/src/main/java/multinewssummarizer/backend/global/exceptionhandler/CustomExceptions.java
@@ -27,4 +27,8 @@ public class CustomExceptions{
     public static class NoBatchNewsDataException extends RuntimeException {
         public NoBatchNewsDataException(String message) {super(message);}
     }
+
+    public static class NoSummaryLogException extends RuntimeException {
+        public NoSummaryLogException(String message) {super(message);}
+    }
 }

--- a/backend/src/main/java/multinewssummarizer/backend/summary/controller/SummaryController.java
+++ b/backend/src/main/java/multinewssummarizer/backend/summary/controller/SummaryController.java
@@ -2,11 +2,8 @@ package multinewssummarizer.backend.summary.controller;
 
 import lombok.RequiredArgsConstructor;
 import multinewssummarizer.backend.global.exceptionhandler.CustomExceptions;
-import multinewssummarizer.backend.summary.model.BatchSummaryResponseDto;
-import multinewssummarizer.backend.summary.model.SummaryRequestDto;
-import multinewssummarizer.backend.summary.model.SummaryResponseDto;
+import multinewssummarizer.backend.summary.model.*;
 import multinewssummarizer.backend.summary.service.SummaryService;
-import multinewssummarizer.backend.summary.model.UserSummaryResponseDto;
 import org.json.simple.parser.ParseException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -33,9 +30,14 @@ public class SummaryController {
     }
 
     @GetMapping("/getusersummary")
-    public ResponseEntity<List<UserSummaryResponseDto>> getSummarizeLogs(@RequestParam("id") Long userId) {
-        List<UserSummaryResponseDto> response = summaryService.getUserSummaryLogs(userId);
+    public ResponseEntity<List<SummaryLogsResponseDto>> getSummarizeLogs(@RequestParam("id") Long userId) {
+        List<SummaryLogsResponseDto> response = summaryService.getUserSummaryLogs(userId);
         return ResponseEntity.ok(response);
+    }
+
+    @ExceptionHandler(CustomExceptions.NoSummaryLogException.class)
+    public ResponseEntity<String> handleNoSummaryLogsException(CustomExceptions.NoSummaryLogException ex) {
+        return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
     }
 
     @GetMapping("/rsscomplete")

--- a/backend/src/main/java/multinewssummarizer/backend/summary/model/BatchSummaryResponseDto.java
+++ b/backend/src/main/java/multinewssummarizer/backend/summary/model/BatchSummaryResponseDto.java
@@ -10,5 +10,5 @@ import java.util.List;
 @NoArgsConstructor
 public class BatchSummaryResponseDto {
     private String summary;
-    private List<BatchSummaryNewsVO> news;
+    private List<SummaryNewsVO> news;
 }

--- a/backend/src/main/java/multinewssummarizer/backend/summary/model/SummaryLogsResponseDto.java
+++ b/backend/src/main/java/multinewssummarizer/backend/summary/model/SummaryLogsResponseDto.java
@@ -1,0 +1,18 @@
+package multinewssummarizer.backend.summary.model;
+
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class SummaryLogsResponseDto {
+    private String summary;
+    private String keywords;
+    private String categories;
+    private LocalDateTime createdTime;
+    private List<SummaryNewsVO> news;
+}

--- a/backend/src/main/java/multinewssummarizer/backend/summary/model/SummaryNewsVO.java
+++ b/backend/src/main/java/multinewssummarizer/backend/summary/model/SummaryNewsVO.java
@@ -6,7 +6,7 @@ import lombok.*;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
-public class BatchSummaryNewsVO {
+public class SummaryNewsVO {
     private String title;
     private String context;
     private String companyName;


### PR DESCRIPTION
- When request Summarize Logs, there need more information about summarize results
- Each of summarize results, there need summarized result, created time, selected topics/keywords, and related News issue #79

## 기능 설명 
- 반환 데이터의 변경으로, 요약 기록 요청 시 내부 로직 변경

<br>


## Key Changes
- SummarizeLog를 모두 불러오면서, 각각의 summarize 기록에 따라 선택한 주제/키워드, 요약된 시간, 사용된 모든 뉴스 데이터들을 반환하도록 로직 변경

<br>


## Related Issue
- issue #79 

<br>