### PR TITLE
[Feat] 뉴스 요청 시간의 범위 변경

### DIFF
--- a/backend/src/main/java/multinewssummarizer/backend/summary/service/SummaryService.java
+++ b/backend/src/main/java/multinewssummarizer/backend/summary/service/SummaryService.java
@@ -20,6 +20,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.*;
 
@@ -40,7 +41,7 @@ public class SummaryService {
         System.out.println("summaryRequestDto = " + summaryRequestDto);
         ArrayList<String> categories = summaryRequestDto.getCategories();
         ArrayList<String> keywords = summaryRequestDto.getKeywords();
-        LocalDateTime oneDayAgo = LocalDateTime.now().minusDays(1);
+        LocalDateTime oneDayAgo = LocalDate.now().minusDays(1).atStartOfDay();
 
         if (categories.isEmpty()) {
             categories = null;
@@ -140,7 +141,7 @@ public class SummaryService {
             System.out.println("categories = " + categories);
             System.out.println("keywords = " + keywords);
 
-            LocalDateTime oneDayAgo = LocalDateTime.now().minusDays(1);
+            LocalDateTime oneDayAgo = LocalDate.now().minusDays(1).atStartOfDay();
             List<SummaryRepositoryVO> findNews = newsRepository.findNewsByCategoriesAndKeywords(categories, keywords, oneDayAgo);
             System.out.println("findNews = " + findNews);
             // 부합하는 뉴스가 없으면 스킵

--- a/backend/src/test/java/multinewssummarizer/backend/news/repository/NewsRepositoryTest.java
+++ b/backend/src/test/java/multinewssummarizer/backend/news/repository/NewsRepositoryTest.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -25,9 +26,12 @@ class NewsRepositoryTest {
         List<String> keywords = new ArrayList<>();
         LocalDateTime oneDayAgo = LocalDateTime.now().minusDays(1);
 
+        LocalDateTime oneDay = LocalDate.now().minusDays(1).atStartOfDay();
+        System.out.println("oneDay = " + oneDay);
+
         categories.add("정치");
         keywords.add("밥");
-        List<SummaryRepositoryVO> output = newsRepository.findNewsByCategoriesAndKeywords(categories, keywords, oneDayAgo);
+        List<SummaryRepositoryVO> output = newsRepository.findNewsByCategoriesAndKeywords(categories, keywords, oneDay);
         System.out.println("output = " + output);
     }
 }


### PR DESCRIPTION
## 기능 설명 
- 주제/키워드에 해당하는 뉴스 데이터를 불러올 때, 불러오는 날짜의 범위를 변경

<br>


## Key Changes
- 이전에는 현재 시간으로부터 하루 전의 데이터를 불러왔지만, 변경하여 오늘로부터 하루 전의 데이터를 불러오는 것으로 변경

<br>


## Related Issue
- issue #107 

<br>